### PR TITLE
Stop continous scanning for Wiimotes

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -708,14 +708,18 @@ void WiimoteScanner::ThreadFunc()
       g_controller_interface.PlatformPopulateDevices([] { ProcessWiimotePool(); });
     }
 
+    if (m_scan_mode.load() == WiimoteScanMode::DO_NOT_SCAN)
+      continue;
+
+    // Stop scanning if not in continous mode.
+    auto scan_mode = WiimoteScanMode::SCAN_ONCE;
+    m_scan_mode.compare_exchange_strong(scan_mode, WiimoteScanMode::DO_NOT_SCAN);
+
     // Does stuff needed to detect disconnects on Windows
     for (const auto& backend : m_backends)
       backend->Update();
 
     CheckForDisconnectedWiimotes();
-
-    if (m_scan_mode.load() == WiimoteScanMode::DO_NOT_SCAN)
-      continue;
 
     // If we don't want Wiimotes in ControllerInterface, we may not need them at all.
     if (!Config::Get(Config::MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE))
@@ -761,10 +765,6 @@ void WiimoteScanner::ThreadFunc()
         }
       }
     }
-
-    // Stop scanning if not in continous mode.
-    auto scan_mode = WiimoteScanMode::SCAN_ONCE;
-    m_scan_mode.compare_exchange_strong(scan_mode, WiimoteScanMode::DO_NOT_SCAN);
   }
 
   {


### PR DESCRIPTION
Applies the changes from PR #9059 in the original Dolphin repository, which wasn’t merged due to concerns about Wiimote connectivity. Since this fork is mainly focused on use with lightguns, it shouldn’t really affect the functionality for its users. The reason I’m opening this PR is to make it compatible with Wiimote software like Touchmote, as continuous scanning doesn’t actually stop and that creates conflicts with the software.